### PR TITLE
Sort keys without block in CSV.instance

### DIFF
--- a/lib/csv.rb
+++ b/lib/csv.rb
@@ -1005,7 +1005,7 @@ class CSV
     def instance(data = $stdout, **options)
       # create a _signature_ for this method call, data object and options
       sig = [data.object_id] +
-            options.values_at(*DEFAULT_OPTIONS.keys.sort_by { |sym| sym.to_s })
+            options.values_at(*DEFAULT_OPTIONS.keys.sort!)
 
       # fetch or create the instance for this signature
       @@instances ||= Hash.new


### PR DESCRIPTION
``DEFAULT_OPTIONS`` is a frozen Hash with symbols as keys.
There is no need to convert such keys to strings before sorting.
Note that sorting is not needed for stable implementations of Hash, keys would always be returned in the same entry order.
We could remove sorting if every supported Ruby implements entry order Hashes.